### PR TITLE
Support JSON as content type to post roles

### DIFF
--- a/src/main/java/jacamo/rest/implementation/RestImplOrg.java
+++ b/src/main/java/jacamo/rest/implementation/RestImplOrg.java
@@ -2,7 +2,6 @@ package jacamo.rest.implementation;
 
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -112,7 +111,7 @@ public class RestImplOrg extends AbstractBinder {
      */
     @Path("/{oename}/groups/{groupname}/roles/{roleid}")
     @POST
-    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Consumes({ MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_JSON })
     @ApiOperation(value = "Add a new role into an organisation/group.")
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "success"),

--- a/src/test/java/jacamo/rest/ClientOrganizationTest.java
+++ b/src/test/java/jacamo/rest/ClientOrganizationTest.java
@@ -56,8 +56,8 @@ public class ClientOrganizationTest {
     }
     
     @Test(timeout=2000)
-    public void test503PostRole() {
-        System.out.println("\n\ntest503PostRole");
+    public void test503PostRoleUrl() {
+        System.out.println("\n\ntest503PostRoleUrl");
         Response response;
         String rStr;
         Form form  = null;
@@ -69,14 +69,39 @@ public class ClientOrganizationTest {
             .post(Entity.form(form));
         
         rStr = response.readEntity(String.class).toString(); 
-        System.out.println("Response (organisations/testOrg/groups/group1/roles/role3: " + rStr);
+        System.out.println("Response (organisations/testOrg/groups/group1/roles/role4: " + rStr);
         assertEquals(200, response.getStatus());
         // GET against organization shows new role
         response = client.target(uri.toString()).path("organisations/testOrg")
                 .request(MediaType.APPLICATION_JSON).get();
         rStr = response.readEntity(String.class).toString(); 
         System.out.println("Response (organisations/testOrg): " + rStr);
-        assertTrue(rStr.contains("role3"));
+        assertTrue(rStr.contains("role4"));
+        
+        client.close();
+    }
+    
+    @Test(timeout=2000)
+    public void test504PostRoleJson() {
+        System.out.println("\n\ntest504PostRoleJson");
+        Response response;
+        String rStr;
+        // POST returns 200 status code
+        response = client
+            .target(uri.toString())
+            .path("organisations/testOrg/groups/group1/roles/role5")
+            .request(MediaType.APPLICATION_JSON)
+            .post(Entity.json(null));
+        
+        rStr = response.readEntity(String.class).toString(); 
+        System.out.println("Response (organisations/testOrg/groups/group1/roles/role5: " + rStr);
+        assertEquals(200, response.getStatus());
+        // GET against organization shows new role
+        response = client.target(uri.toString()).path("organisations/testOrg")
+                .request(MediaType.APPLICATION_JSON).get();
+        rStr = response.readEntity(String.class).toString(); 
+        System.out.println("Response (organisations/testOrg): " + rStr);
+        assertTrue(rStr.contains("role5"));
         
         client.close();
     }


### PR DESCRIPTION
@cleberjamaral When I implemented the organization tests, I noticed that the content type for posting new roles (URL encoded) is inconsistent with the content type required by other posts (JSON). I am not sure if this is "by design". But even if this is the case, it would be good to allow for consistent content types (to not confuse developers). In this PR, I add support for JSON as an _additional_ content type for the post role handler. However, if the specification of URL encoded content for this handler was a mistake in the first place, and if we can break backwards compatibility, it might make sense to adjust this PR and remove support for URL encoded content altogether.