### PR TITLE
Add postAgentProgram and addAgentProgram methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ jar {
 
 task copyToLib(type: Copy) {
     into "$buildDir/libs"
-    from(configurations.compile)
+    from(configurations.implementation)
 }
 
 task stage(dependsOn: ['jar', 'copyToLib', 'clean']) {

--- a/src/main/java/jacamo/rest/implementation/RestImplAg.java
+++ b/src/main/java/jacamo/rest/implementation/RestImplAg.java
@@ -299,10 +299,10 @@ public class RestImplAg extends AbstractBinder {
     }
 
     /**
-     * Append new plans into an agent.
+     * Append new pieces or the whole program into an agent.
      *
      * @param agName              name of the agent
-     * @param plans               plans to be uploaded, as an String
+     * @param program             program to be uploaded, as an String
      * @return HTTP 200 Response (ok status) or 500 Internal Server Error in case of
      *         error (based on https://tools.ietf.org/html/rfc7231#section-6.6.1)
      */

--- a/src/main/java/jacamo/rest/implementation/RestImplAg.java
+++ b/src/main/java/jacamo/rest/implementation/RestImplAg.java
@@ -306,6 +306,34 @@ public class RestImplAg extends AbstractBinder {
      * @return HTTP 200 Response (ok status) or 500 Internal Server Error in case of
      *         error (based on https://tools.ietf.org/html/rfc7231#section-6.6.1)
      */
+    @Path("/{agentname}/program")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Append new pieces or the whole program into an agent.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "success"),
+            @ApiResponse(code = 500, message = "internal error")
+    })
+    public Response postAgentProgram(@PathParam("agentname") String agName, String program) {
+        try {
+            tAg.addAgentProgram(agName, program);
+            return Response
+                    .ok()
+                    .build();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Response.status(500, e.getMessage()).build();
+        }
+    }
+
+    /**
+     * Append new plans into an agent.
+     *
+     * @param agName              name of the agent
+     * @param plans               plans to be uploaded, as an String
+     * @return HTTP 200 Response (ok status) or 500 Internal Server Error in case of
+     *         error (based on https://tools.ietf.org/html/rfc7231#section-6.6.1)
+     */
     @Path("/{agentname}/plans")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/src/main/java/jacamo/rest/mediation/TranslAg.java
+++ b/src/main/java/jacamo/rest/mediation/TranslAg.java
@@ -252,7 +252,7 @@ public class TranslAg {
         if (ag == null) {
             throw new Exception("Receiver '" + agName + "' not found");
         }
-        ag.parseAS(new StringReader(plans), "RestAPI");
+        ag.load(new StringInputStream(plans), "source-from-rest-api");
     }
 
     /**

--- a/src/main/java/jacamo/rest/mediation/TranslAg.java
+++ b/src/main/java/jacamo/rest/mediation/TranslAg.java
@@ -241,6 +241,21 @@ public class TranslAg {
     }
 
     /**
+     * Add a piece or the whole agent's program
+     *
+     * @param agName
+     * @param program
+     * @throws Exception
+     */
+    public void addAgentProgram(String agName, String program) throws Exception {
+        Agent ag = getAgent(agName);
+        if (ag == null) {
+            throw new Exception("Receiver '" + agName + "' not found");
+        }
+        ag.load(new StringInputStream(program), "source-from-rest-api");
+    }
+
+    /**
      * Add a plan to the agent's plan library
      *
      * @param agName
@@ -252,7 +267,7 @@ public class TranslAg {
         if (ag == null) {
             throw new Exception("Receiver '" + agName + "' not found");
         }
-        ag.load(new StringInputStream(plans), "source-from-rest-api");
+        ag.parseAS(new StringReader(plans), "RestAPI");
     }
 
     /**

--- a/src/test/java/jacamo/rest/ClientAgentTest.java
+++ b/src/test/java/jacamo/rest/ClientAgentTest.java
@@ -360,6 +360,67 @@ public class ClientAgentTest {
         client.close();
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test012PostAgentProgram() {
+        System.out.println("\n\ntest012PostAgentProgram");
+        Response response;
+        String rStr;
+
+        // 1. add program
+        response = client.target(uri.toString())
+                .path("agents/marcos/program")
+                .request()
+                .accept(MediaType.TEXT_PLAIN)
+                .post(
+                        Entity.json(
+                                "+!pp <- .print(\"Plan pp\").\n" +
+                                "+qq <- .print(\"Plan qq\").\n" +
+                                "!pp.\n" +
+                                "qq."
+                                )
+                        );
+        System.out.println("Post a new program to marcos");
+        assertEquals(200, response.getStatus());
+
+        // 2. check plans
+        response = client.target(uri.toString()).path("agents/marcos/plans")
+                .request(MediaType.APPLICATION_JSON).get();
+        Map<String,String> m = response.readEntity(Map.class);
+        Iterator<String> i = m.values().iterator();
+        String p = "";
+        while (i.hasNext()) {
+            p = i.next();
+            if (p.contains(".print(\"Plan pp\").")) {
+                System.out.println("A response (agents/marcos/plans): " + p);
+                break;
+            }
+        }
+        assertTrue(p.contains(".print(\"Plan pp\")."));
+
+        i = m.values().iterator();
+        p = "";
+        while (i.hasNext()) {
+            p = i.next();
+            if (p.contains(".print(\"Plan qq\").")) {
+                System.out.println("A response (agents/marcos/plans): " + p);
+                break;
+            }
+        }
+        assertTrue(p.contains(".print(\"Plan qq\")."));
+
+        // 3. test beliefs
+        response = client.target(uri.toString())
+                .path("agents/marcos/bb")
+                .request(MediaType.APPLICATION_JSON).get();
+
+        rStr = response.readEntity(String.class);
+        System.out.println(rStr);
+        assertTrue(rStr.contains("qq[source(self)]"));
+
+        client.close();
+    }
+
     @Test
     @SuppressWarnings("rawtypes")
     public void test401PostWP() throws Exception {


### PR DESCRIPTION
This pull request adds the postAgentProgram and addAgentProgram methods.

With the current methods it was not possible to POST a whole program through the API. Using the POST /plans, the beliefs and intentions are ignored and just the plans are added.

- Added method that can load into the agent anything that can be written in an ASL code.

- The method is very similar to the addAgentPlan, but instead of using the agent.parseAS() function to parse and load the input strings, the addAgentProgram uses the agent.load() function. This method makes it easier to send the agent's code via API.

- Added a test for postAgentProgram.

- Updated the build.gradle for building the .jar lib, as the configuration.compile is now deprecated.

