### PR TITLE
Add the host-address parameter

### DIFF
--- a/src/main/java/jacamo/rest/JCMRest.java
+++ b/src/main/java/jacamo/rest/JCMRest.java
@@ -40,6 +40,7 @@ public class JCMRest extends DefaultPlatformImpl {
     protected URI restServerURI = null;
     protected String mainRest = null;
     protected String registerURL = null;
+    protected String hostAddress = null;
 
     protected Map<String, Map<String,Object>> ans = new TreeMap<>();     // agent name service (agent name -> ( prop -> value )* )
     protected Map<String, Map<String,Object>> mdCache = new HashMap<>(); // meta data cache
@@ -118,6 +119,11 @@ public class JCMRest extends DefaultPlatformImpl {
                     if (!registerURL.endsWith("/"))
                         registerURL += "/";
                 }
+                
+                if(la.equals("--host-address")){
+                   hostAddress = a;
+                }
+
 
                 la = a;
             }
@@ -154,7 +160,12 @@ public class JCMRest extends DefaultPlatformImpl {
             return null;
         }
         try {
-            restServerURI = UriBuilder.fromUri("http://"+InetAddress.getLocalHost().getHostAddress()+"/").port(port).build();
+        
+            if(hostAddress==null)
+               restServerURI = UriBuilder.fromUri("http://"+InetAddress.getLocalHost().getHostAddress()+"/").port(port).build();
+            else
+               restServerURI = UriBuilder.fromUri("http://"+ hostAddress +"/").port(port).build();
+               
 
             RestAppConfig rc = new RestAppConfig();
 


### PR DESCRIPTION
Adding the parameter `host-address` in the JaCaMo-REST platform configuration in jcm.

This parameter sets the IP address to be considered as the host address. It is necessary to exchange messages with agents hosted in different hosts.

Example:
```
platform: jacamo.rest.JCMRest("--rest-port 8080 --host-address 192.168.2.11")
```